### PR TITLE
Adds paginable GET for all vulnerabilities

### DIFF
--- a/anakata/project.clj
+++ b/anakata/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [metosin/compojure-api "1.0.2"]]
+                 [metosin/compojure-api "1.0.2"]
+                 [clojurewerkz/elastisch "2.2.1"]]
   :ring {:handler anakata.core/ithazards}
   :profiles {:dev {
                    :plugins [[lein-ring "0.9.7"]]

--- a/anakata/project.clj
+++ b/anakata/project.clj
@@ -9,5 +9,6 @@
   :ring {:handler anakata.core/ithazards}
   :profiles {:dev {
                    :plugins [[lein-ring "0.9.7"]]
-                   :dependencies [[javax.servlet/servlet-api "2.5"]]
+                   :dependencies [[javax.servlet/servlet-api "2.5"]
+                                  [midje "1.6.3"]]
                    :ring {:port 3001}}})

--- a/anakata/src/anakata/core.clj
+++ b/anakata/src/anakata/core.clj
@@ -15,33 +15,39 @@
    :summary s/Str
    :affected-software [s/Str]})
 
-(defonce vulnerabilities (atom []))
+(defn ensure-vulnerability [vulnerability]
+  (if (not (contains? vulnerability :affected-software))
+    (assoc vulnerability :affected-software [])
+    vulnerability))
 
-(defn add! [new-vulnerability]
-  (swap! vulnerabilities conj new-vulnerability))
+(defn read-vulnerabilities [hits]
+  (let [hit (first hits)]
+    (if hit
+      (do
+        (conj
+          (read-vulnerabilities (rest hits))
+          (ensure-vulnerability (get hit :_source))))
+      [])))
 
-(defn get-vulnerabilities []
+(defn get-vulnerabilities [from size]
   (let [conn (esr/connect "http://127.0.0.1:9200")
-        res (esd/search conn "vulnerabilities" "vulnerability")
+        res (esd/search conn "vulnerabilities" "vulnerability"
+                        :from from
+                        :size size)
         hits (esrsp/hits-from res)]
-    (loop [results hits]
-      (let [hit (first results)]
-        (if hit
-          (do
-            (add! (get hit :_source))
-            (recur (rest results))))))
-    (-> vulnerabilities deref)))
+      (read-vulnerabilities hits)))
 
 (def ithazards
   (api
-   {:swagger
-    {:ui "/"
-     :spec "/swagger.json"
-     :data {:info {:title "IT Hazards"}
-            :tags [{:name "api"}]}}}
-   (context "/vulnerabilities" []
-            :tags ["vulnerabilities"]
-            (GET "/" []
-                 :return [Vulnerability]
-                 :summary "Gets vulnerabilities"
-                 (ok (get-vulnerabilities))))))
+    {:swagger
+      {:ui "/"
+       :spec "/swagger.json"
+       :data {:info {:title "IT Hazards"}
+              :tags [{:name "api"}]}}}
+    (context "/vulnerabilities" []
+      :tags ["vulnerabilities"]
+      (GET "/" []
+        :return [Vulnerability]
+        :header-params [{from :- s/Int 0} {size :- s/Int 10}]
+        :summary "Gets vulnerabilities"
+        (ok (get-vulnerabilities from size))))))

--- a/anakata/test/anakata/core_test.clj
+++ b/anakata/test/anakata/core_test.clj
@@ -17,8 +17,56 @@
 
 (facts "about `ensure-vulnerability`"
        (fact "it returns vulnerability with affected-software"
-             (contains? (ensure-vulnerability incomplete-vuln-data) :affected-software) => true
-             (contains? (ensure-vulnerability complete-vuln-data) :affected-software) => true)
-       (fact "it returns untouched vulnerability when affected-software is present"
-             (get (ensure-vulnerability incomplete-vuln-data) :affected-software) => []
-             (get (ensure-vulnerability complete-vuln-data) :affected-software) => ["Some software"]))
+             (let [incomplete-vuln (ensure-vulnerability incomplete-vuln-data)]
+                  (contains? incomplete-vuln :affected-software) => true
+                  (get incomplete-vuln :cve-id) => "CVE-0000-0000"
+                  (get incomplete-vuln :affected-software) => []
+                  )
+             (let [complete-vuln (ensure-vulnerability complete-vuln-data)]
+                  (contains? complete-vuln :affected-software) => true
+                  (get complete-vuln :cve-id) => "CVE-0001-0001"
+                  (get complete-vuln :affected-software) => ["Some software"])))
+
+(def vulnerabilities-data
+  [{:_source incomplete-vuln-data} {:_source complete-vuln-data}])
+
+(facts "about `read-vulnerabilities`"
+       (fact "it returns a list of vulnerabilities"
+             (let [vulnerabilities (read-vulnerabilities vulnerabilities-data)]
+                  (clojure.core/count vulnerabilities) => (clojure.core/count vulnerabilities-data)
+                  (get (first vulnerabilities) :cve-id) => (get complete-vuln-data :cve-id)
+                  (get (second vulnerabilities) :cve-id) => (get incomplete-vuln-data :cve-id))))
+
+(def vulnerabilities-data-1
+  [{:_source incomplete-vuln-data}])
+
+(def vulnerabilities-data-2
+  [{:_source complete-vuln-data}])
+
+(facts "about `get-vulnerabilities`"
+       (fact "it returns a list of vulnerabilities"
+             (prerequisites (get-response "vulnerabilities"
+                                          "vulnerability"
+                                          0
+                                          10) => vulnerabilities-data)
+             (let [vulnerabilities (get-vulnerabilities 0 10)]
+               (clojure.core/count vulnerabilities) => (clojure.core/count vulnerabilities-data)
+               (get (first vulnerabilities) :cve-id) => (get complete-vuln-data :cve-id)
+               (get (second vulnerabilities) :cve-id) => (get incomplete-vuln-data :cve-id)))
+       (fact "it returns a paged list of vulnerabilities"
+             (prerequisites (get-response "vulnerabilities"
+                                          "vulnerability"
+                                          0
+                                          1) => vulnerabilities-data-1
+                            (get-response "vulnerabilities"
+                                          "vulnerability"
+                                          1
+                                          1) => vulnerabilities-data-2)
+             (let [vulnerabilities (get-vulnerabilities 0 1)
+                   vulnerabilities2 (get-vulnerabilities 1 1)]
+               (clojure.core/count vulnerabilities) => (clojure.core/count vulnerabilities-data-1)
+               (clojure.core/count vulnerabilities2) => (clojure.core/count vulnerabilities-data-2)
+               (get (first vulnerabilities) :cve-id) => (get incomplete-vuln-data :cve-id)
+               (get (first vulnerabilities2) :cve-id) => (get complete-vuln-data :cve-id)
+               ))
+       )

--- a/anakata/test/anakata/core_test.clj
+++ b/anakata/test/anakata/core_test.clj
@@ -1,7 +1,24 @@
 (ns anakata.core-test
+  (:use midje.sweet)
   (:require [clojure.test :refer :all]
             [anakata.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(def incomplete-vuln-data
+  {:cve-id "CVE-0000-0000"
+   :published "2001-09-10 10:00:00"
+   :last-modified "2001-09-10 10:00:00"
+   :summary "Brief summary of incomplete vulnerability"})
+(def complete-vuln-data
+  {:cve-id "CVE-0001-0001"
+   :published "2001-09-10 10:00:00"
+   :last-modified "2001-09-10 10:00:00"
+   :summary "Brief summary of complete vulnerability"
+   :affected-software ["Some software"]})
+
+(facts "about `ensure-vulnerability`"
+       (fact "it returns vulnerability with affected-software"
+             (contains? (ensure-vulnerability incomplete-vuln-data) :affected-software) => true
+             (contains? (ensure-vulnerability complete-vuln-data) :affected-software) => true)
+       (fact "it returns untouched vulnerability when affected-software is present"
+             (get (ensure-vulnerability incomplete-vuln-data) :affected-software) => []
+             (get (ensure-vulnerability complete-vuln-data) :affected-software) => ["Some software"]))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,14 @@ services:
   api:
     build: anakata/
     container_name: api
+    environment:
+      - ES_URL=http://elasticsearch:9200
     ports:
       - "3001:3001"
     network_mode: bridge
     depends_on:
       - search
+      - parser
     links:
       - search
     healthcheck:


### PR DESCRIPTION
With this, it should be possible to run the following:
```bash
docker-compose up --build
```
And, once this is finished:
* ElasticSearch should be ready at http://localhost:9200/vulnerabilities/_search and return some documents;
* Anakata should be listening at http://localhost:3001, and, by going to http://localhost:3001/index.html#!/vulnerabilities/get_vulnerabilities and get paged results.
* Phiber-optik should be also available, but not capable to do anything yet.

Also, by running:
```bash
cd anakata && lein midje
```
16 tests on Anakata should pass.
